### PR TITLE
add keyword handling

### DIFF
--- a/src/DE9IM.jl
+++ b/src/DE9IM.jl
@@ -19,8 +19,30 @@ Abstract type for all DE9IM predicates objects.
 """
 abstract type DE9IMPredicate{T} end
 
+# Allows passing keyword arguments into a predicate,
+# for interpretation later in the context they are used in.
+struct ArgWithKeywords{T,KW} 
+    val::T 
+    keywords::KW
+end
+
+keywords(::DE9IMPredicate) = NamedTuple()
+keywords(p::DE9IMPredicate{<:ArgWithKeywords}) = keywords(p.val)
+keywords(p::ArgWithKeywords) = p.keywords
+
 Base.parent(p::DE9IMPredicate) = p.val
-Base.eltype(p::DE9IMPredicate{T}) where T = T
+Base.parent(p::DE9IMPredicate{<:ArgWithKeywords}) = parent(p.val)
+Base.parent(p::ArgWithKeywords) = p.val
+
+Base.eltype(::DE9IMPredicate{T}) where T = T
+Base.eltype(::ArgWithKeywords{T}) where T = T
+Base.eltype(::DE9IMPredicate{<:ArgWithKeywords{T}}) where T = T
+
+(::Type{T})(; kw...) where {T<:DE9IMPredicate} = T(_maybe_wrap(nothing, values(kw)))
+(::Type{T})(x; kw...) where {T<:DE9IMPredicate} = T(_maybe_wrap(x, values(kw)))
+
+_maybe_wrap(a, ::NamedTuple{(),Tuple{}}) = a
+_maybe_wrap(a, kw::NamedTuple) = ArgWithKeywords(a, kw)
 
 """
     Intersects{T} <: DE9IMPredicate{T}
@@ -54,7 +76,6 @@ If `Disjoint` wraps an object passed to a predicate function, it must be the sec
 struct Disjoint{T} <: DE9IMPredicate{T}
     val::T
 end
-Disjoint() = Disjoint(nothing)
 
 """
     Contains{T} <: DE9IMPredicate{T}
@@ -71,7 +92,6 @@ If `Contains` wraps an object passed to a predicate function, it must be the sec
 struct Contains{T} <: DE9IMPredicate{T}
     val::T
 end
-Contains() = Contains(nothing)
 
 """
     Within{T} <: DE9IMPredicate{T}
@@ -88,7 +108,6 @@ If `Within` wraps an object passed to a predicate function, it must be the secon
 struct Within{T} <: DE9IMPredicate{T}
     val::T
 end
-Within() = Within(nothing)
 
 """
     Covers{T} <: DE9IMPredicate{T}
@@ -105,7 +124,6 @@ If `Covers` wraps an object passed to a predicate function, it must be the secon
 struct Covers{T} <: DE9IMPredicate{T}
     val::T
 end
-Covers() = Covers(nothing)
 
 """
     CoveredBy{T} <: DE9IMPredicate{T}
@@ -122,7 +140,6 @@ If `CoveredBy` wraps an object passed to a predicate function, it must be the se
 struct CoveredBy{T} <: DE9IMPredicate{T}
     val::T
 end
-CoveredBy() = CoveredBy(nothing)
 
 """
     Touches{T} <: DE9IMPredicate{T}
@@ -137,7 +154,6 @@ A `Touches` predicate returns true if the two geometries have at least one point
 struct Touches{T} <: DE9IMPredicate{T}
     val::T
 end
-Touches() = Touches(nothing)
 
 """
     Crosses{T} <: DE9IMPredicate{T}
@@ -152,7 +168,6 @@ A `Crosses` predicate returns true if the two geometries have some but not all i
 struct Crosses{T} <: DE9IMPredicate{T}
     val::T
 end
-Crosses() = Crosses(nothing)
 
 """
     Overlaps{T} <: DE9IMPredicate{T}
@@ -165,7 +180,6 @@ An `Overlaps` predicate returns true if the two geometries have some interior po
 struct Overlaps{T} <: DE9IMPredicate{T}
     val::T
 end
-Overlaps() = Overlaps(nothing)
 
 """
     Equals{T} <: DE9IMPredicate{T}
@@ -178,6 +192,5 @@ An `Equals` predicate returns true if the two geometries have the same boundary 
 struct Equals{T} <: DE9IMPredicate{T}
     val::T
 end
-Equals() = Equals(nothing)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using DE9IM
 using Test
 
+using DE9IM: keywords
+
 @testset "DE9IM.jl" begin
     @testset "Constructors" begin
         @test Intersects() == Intersects(nothing)
@@ -11,33 +13,46 @@ using Test
         @test CoveredBy() == CoveredBy(nothing)
         @test Touches() == Touches(nothing)
         @test Crosses() == Crosses(nothing)
-        @test Overlaps() == Overlaps(nothing)
+        @test Overlaps() == Overlaps(nothing) 
         @test Equals() == Equals(nothing)
     end
 
+    @testset "keywords" begin
+        @test keywords(Intersects(3.0; foo=:bar)) == keywords(Intersects(; foo=:bar)) == (; foo=:bar)
+        @test keywords(Disjoint(3.0; foo=:bar)) == keywords(Disjoint(; foo=:bar)) == (; foo=:bar)
+        @test keywords(Contains(3.0; foo=:bar)) == keywords(Contains(; foo=:bar)) == (; foo=:bar)
+        @test keywords(Within(3.0; foo=:bar)) == keywords(Within(; foo=:bar)) == (; foo=:bar)
+        @test keywords(Covers(3.0; foo=:bar)) == keywords(Covers(; foo=:bar)) == (; foo=:bar)
+        @test keywords(CoveredBy(3.0; foo=:bar)) == keywords(CoveredBy(; foo=:bar)) == (; foo=:bar)
+        @test keywords(Touches(3.0; foo=:bar)) == keywords(Touches(; foo=:bar)) == (; foo=:bar)
+        @test keywords(Crosses(3.0; foo=:bar)) == keywords(Crosses(; foo=:bar)) == (; foo=:bar)
+        @test keywords(Overlaps(3.0; foo=:bar)) == keywords(Overlaps(; foo=:bar)) == (; foo=:bar)
+        @test keywords(Equals(3.0; foo=:bar)) == keywords(Equals(; foo=:bar)) == (; foo=:bar)
+    end
+
     @testset "parent" begin
-        @test parent(Intersects(3.0)) == 3.0
-        @test parent(Disjoint(3.0)) == 3.0
-        @test parent(Contains(3.0)) == 3.0
-        @test parent(Within(3.0)) == 3.0
-        @test parent(Covers(3.0)) == 3.0
-        @test parent(CoveredBy(3.0)) == 3.0
-        @test parent(Touches(3.0)) == 3.0
-        @test parent(Crosses(3.0)) == 3.0
-        @test parent(Overlaps(3.0)) == 3.0
-        @test parent(Equals(3.0)) == 3.0
+        @test parent(Intersects(3.0)) == parent(Intersects(3.0; foo=:bar)) == 3.0
+        @test parent(Disjoint(3.0)) == parent(Disjoint(3.0; foo=:bar)) == 3.0
+        @test parent(Contains(3.0)) == parent(Contains(3.0; foo=:bar)) == 3.0
+        @test parent(Within(3.0)) == parent(Within(3.0; foo=:bar)) == 3.0
+        @test parent(Covers(3.0)) == parent(Covers(3.0; foo=:bar)) == 3.0
+        @test parent(CoveredBy(3.0)) == parent(CoveredBy(3.0; foo=:bar)) == 3.0
+        @test parent(Touches(3.0)) == parent(Touches(3.0; foo=:bar)) == 3.0
+        @test parent(Crosses(3.0)) == parent(Crosses(3.0; foo=:bar)) == 3.0
+        @test parent(Overlaps(3.0)) == parent(Overlaps(3.0; foo=:bar)) == 3.0
+        @test parent(Equals(3.0)) == parent(Equals(3.0; foo=:bar)) == 3.0
     end
 
     @testset "eltype" begin
-        @test eltype(Intersects(3.0)) == Float64
-        @test eltype(Disjoint(3.0)) == Float64
-        @test eltype(Contains(3.0)) == Float64
-        @test eltype(Within(3.0)) == Float64
-        @test eltype(Covers(3.0)) == Float64
-        @test eltype(CoveredBy(3.0)) == Float64
-        @test eltype(Touches(3.0)) == Float64
-        @test eltype(Crosses(3.0)) == Float64
-        @test eltype(Overlaps(3.0)) == Float64
-        @test eltype(Equals(3.0)) == Float64
+        @test eltype(Intersects(3.0)) == eltype(Intersects(3.0; kw=true)) == Float64
+        @test eltype(Disjoint(3.0)) == eltype(Disjoint(3.0; kw=true)) == Float64
+        @test eltype(Contains(3.0)) == eltype(Contains(3.0; kw=true)) == Float64
+        @test eltype(Within(3.0)) == eltype(Within(3.0; kw=true)) == Float64
+        @test eltype(Covers(3.0)) == eltype(Covers(3.0; kw=true)) == Float64
+        @test eltype(CoveredBy(3.0)) == eltype(CoveredBy(3.0; kw=true)) == Float64
+        @test eltype(Touches(3.0)) == eltype(Touches(3.0; kw=true)) == Float64
+        @test eltype(Crosses(3.0)) == eltype(Crosses(3.0; kw=true)) == Float64
+        @test eltype(Overlaps(3.0)) == eltype(Overlaps(3.0; kw=true)) == Float64
+        @test eltype(Equals(3.0)) == eltype(Equals(3.0; kw=true)) == Float64
     end
 end;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,17 @@ using DE9IM: keywords
         @test keywords(Crosses(3.0; foo=:bar)) == keywords(Crosses(; foo=:bar)) == (; foo=:bar)
         @test keywords(Overlaps(3.0; foo=:bar)) == keywords(Overlaps(; foo=:bar)) == (; foo=:bar)
         @test keywords(Equals(3.0; foo=:bar)) == keywords(Equals(; foo=:bar)) == (; foo=:bar)
+
+        @test keywords(Intersects()) == (;)
+        @test keywords(Disjoint()) == (;)
+        @test keywords(Contains()) == (;)
+        @test keywords(Within()) == (;)
+        @test keywords(Covers()) == (;)
+        @test keywords(CoveredBy()) == (;)
+        @test keywords(Touches()) == (;)
+        @test keywords(Crosses()) == (;)
+        @test keywords(Overlaps()) == (;)
+        @test keywords(Equals()) == (;)
     end
 
     @testset "parent" begin


### PR DESCRIPTION
Allows `Covers(x; foo=:bar)` storing the keywords in an inner wrapper, that can be used later.

I think the keyword interface has to remain the responsibility of the ingesting package for now.